### PR TITLE
feat(api): add leaderboards system with global and game rankings

### DIFF
--- a/apps/web/src/app/api/leaderboards/[game]/route.ts
+++ b/apps/web/src/app/api/leaderboards/[game]/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/db'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ game: string }> }
+) {
+  try {
+    const { game } = await params
+    const { searchParams } = new URL(request.url)
+    const limit = parseInt(searchParams.get('limit') || '10')
+    const period = searchParams.get('period') || 'all'
+
+    // Validate limit
+    if (limit < 1 || limit > 100) {
+      return NextResponse.json(
+        { error: 'Limit must be between 1 and 100' },
+        { status: 400 }
+      )
+    }
+
+    // Find game by slug
+    const gameRecord = await prisma.game.findUnique({
+      where: { slug: game },
+    })
+
+    if (!gameRecord) {
+      return NextResponse.json({ error: 'Game not found' }, { status: 404 })
+    }
+
+    // Calculate date filter based on period
+    let dateFilter: { createdAt?: { gte: Date } } = {}
+    if (period === 'daily') {
+      const today = new Date()
+      today.setHours(0, 0, 0, 0)
+      dateFilter = { createdAt: { gte: today } }
+    } else if (period === 'weekly') {
+      const weekAgo = new Date()
+      weekAgo.setDate(weekAgo.getDate() - 7)
+      weekAgo.setHours(0, 0, 0, 0)
+      dateFilter = { createdAt: { gte: weekAgo } }
+    }
+
+    // Get top scores for this game
+    const topScores = await prisma.gameScore.findMany({
+      where: {
+        gameId: gameRecord.id,
+        ...dateFilter,
+      },
+      orderBy: { score: 'desc' },
+      take: limit,
+      include: {
+        user: {
+          select: {
+            id: true,
+            walletAddress: true,
+            username: true,
+            avatar: true,
+          },
+        },
+      },
+    })
+
+    // Build leaderboard response
+    const leaderboard = topScores.map((score, index) => ({
+      rank: index + 1,
+      wallet: score.user.walletAddress,
+      username: score.user.username,
+      avatar: score.user.avatar,
+      score: score.score,
+      grepEarned: score.grepEarned,
+      playedAt: score.createdAt,
+    }))
+
+    return NextResponse.json({
+      game: {
+        slug: gameRecord.slug,
+        name: gameRecord.name,
+      },
+      leaderboard,
+      period,
+      updatedAt: new Date().toISOString(),
+    })
+  } catch (error) {
+    console.error('Game leaderboard fetch error:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch game leaderboard' },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/web/src/app/api/leaderboards/rankings/route.ts
+++ b/apps/web/src/app/api/leaderboards/rankings/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import prisma from '@/lib/db'
+import { parseSessionToken } from '@/lib/auth'
+
+export async function GET(request: NextRequest) {
+  try {
+    const cookieStore = await cookies()
+    const sessionToken = cookieStore.get('session')?.value
+
+    if (!sessionToken) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+    }
+
+    const session = parseSessionToken(sessionToken)
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid session' }, { status: 401 })
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { walletAddress: session.address },
+    })
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const period = searchParams.get('period') || 'all'
+    const nearby = parseInt(searchParams.get('nearby') || '3')
+
+    // Calculate date filter based on period
+    let dateFilter = {}
+    if (period === 'daily') {
+      const today = new Date()
+      today.setHours(0, 0, 0, 0)
+      dateFilter = { createdAt: { gte: today } }
+    } else if (period === 'weekly') {
+      const weekAgo = new Date()
+      weekAgo.setDate(weekAgo.getDate() - 7)
+      weekAgo.setHours(0, 0, 0, 0)
+      dateFilter = { createdAt: { gte: weekAgo } }
+    }
+
+    // Get all users with their total GREP earned
+    const allUserScores = await prisma.gameScore.groupBy({
+      by: ['userId'],
+      where: dateFilter,
+      _sum: {
+        grepEarned: true,
+        score: true,
+      },
+      _count: {
+        id: true,
+      },
+      orderBy: {
+        _sum: {
+          grepEarned: 'desc',
+        },
+      },
+    })
+
+    // Find user's rank
+    const userRankIndex = allUserScores.findIndex((s) => s.userId === user.id)
+    const userRank = userRankIndex === -1 ? null : userRankIndex + 1
+    const userStats = allUserScores[userRankIndex]
+
+    // Get nearby players
+    const startIndex = Math.max(0, userRankIndex - nearby)
+    const endIndex = Math.min(allUserScores.length, userRankIndex + nearby + 1)
+    const nearbyScores = allUserScores.slice(startIndex, endIndex)
+
+    // Get user details for nearby players
+    const nearbyUserIds = nearbyScores.map((s) => s.userId)
+    const nearbyUsers = await prisma.user.findMany({
+      where: { id: { in: nearbyUserIds } },
+      select: {
+        id: true,
+        walletAddress: true,
+        username: true,
+        avatar: true,
+      },
+    })
+
+    const userMap = new Map(nearbyUsers.map((u) => [u.id, u]))
+
+    const nearbyPlayers = nearbyScores.map((score, index) => {
+      const nearbyUser = userMap.get(score.userId)
+      return {
+        rank: startIndex + index + 1,
+        wallet: nearbyUser?.walletAddress || '',
+        username: nearbyUser?.username || null,
+        avatar: nearbyUser?.avatar || null,
+        score: score._sum.score || 0,
+        grepEarned: score._sum.grepEarned || 0,
+        gamesPlayed: score._count.id,
+        isCurrentUser: score.userId === user.id,
+      }
+    })
+
+    return NextResponse.json({
+      userRanking: {
+        rank: userRank,
+        totalPlayers: allUserScores.length,
+        score: userStats?._sum.score || 0,
+        grepEarned: userStats?._sum.grepEarned || 0,
+        gamesPlayed: userStats?._count.id || 0,
+      },
+      nearbyPlayers,
+      period,
+      updatedAt: new Date().toISOString(),
+    })
+  } catch (error) {
+    console.error('Rankings fetch error:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch rankings' },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/web/src/app/api/leaderboards/route.ts
+++ b/apps/web/src/app/api/leaderboards/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/db'
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const limit = parseInt(searchParams.get('limit') || '10')
+    const period = searchParams.get('period') || 'all' // all, weekly, daily
+
+    // Validate limit
+    if (limit < 1 || limit > 100) {
+      return NextResponse.json(
+        { error: 'Limit must be between 1 and 100' },
+        { status: 400 }
+      )
+    }
+
+    // Calculate date filter based on period
+    let dateFilter = {}
+    if (period === 'daily') {
+      const today = new Date()
+      today.setHours(0, 0, 0, 0)
+      dateFilter = { createdAt: { gte: today } }
+    } else if (period === 'weekly') {
+      const weekAgo = new Date()
+      weekAgo.setDate(weekAgo.getDate() - 7)
+      weekAgo.setHours(0, 0, 0, 0)
+      dateFilter = { createdAt: { gte: weekAgo } }
+    }
+
+    // Aggregate total GREP earned by user
+    const userScores = await prisma.gameScore.groupBy({
+      by: ['userId'],
+      where: dateFilter,
+      _sum: {
+        score: true,
+        grepEarned: true,
+      },
+      _count: {
+        id: true,
+      },
+      orderBy: {
+        _sum: {
+          grepEarned: 'desc',
+        },
+      },
+      take: limit,
+    })
+
+    // Get user details
+    const userIds = userScores.map((s) => s.userId)
+    const users = await prisma.user.findMany({
+      where: { id: { in: userIds } },
+      select: {
+        id: true,
+        walletAddress: true,
+        username: true,
+        avatar: true,
+      },
+    })
+
+    const userMap = new Map(users.map((u) => [u.id, u]))
+
+    // Build leaderboard response
+    const leaderboard = userScores.map((score, index) => {
+      const user = userMap.get(score.userId)
+      return {
+        rank: index + 1,
+        wallet: user?.walletAddress || '',
+        username: user?.username || null,
+        avatar: user?.avatar || null,
+        score: score._sum.score || 0,
+        grepEarned: score._sum.grepEarned || 0,
+        gamesPlayed: score._count.id,
+      }
+    })
+
+    return NextResponse.json({
+      leaderboard,
+      period,
+      updatedAt: new Date().toISOString(),
+    })
+  } catch (error) {
+    console.error('Leaderboard fetch error:', error)
+    return NextResponse.json(
+      { error: 'Failed to fetch leaderboard' },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/web/src/hooks/useLeaderboards.ts
+++ b/apps/web/src/hooks/useLeaderboards.ts
@@ -1,0 +1,155 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+interface LeaderboardEntry {
+  rank: number
+  wallet: string
+  username: string | null
+  avatar: string | null
+  score: number
+  grepEarned: number
+  gamesPlayed?: number
+  playedAt?: string
+  isCurrentUser?: boolean
+}
+
+interface GameInfo {
+  slug: string
+  name: string
+}
+
+interface LeaderboardResponse {
+  leaderboard: LeaderboardEntry[]
+  period: string
+  updatedAt: string
+  game?: GameInfo
+}
+
+interface UserRanking {
+  rank: number | null
+  totalPlayers: number
+  score: number
+  grepEarned: number
+  gamesPlayed: number
+}
+
+interface RankingsResponse {
+  userRanking: UserRanking
+  nearbyPlayers: LeaderboardEntry[]
+  period: string
+  updatedAt: string
+}
+
+interface UseLeaderboardsOptions {
+  limit?: number
+  period?: 'all' | 'weekly' | 'daily'
+  game?: string
+}
+
+export function useLeaderboards(options: UseLeaderboardsOptions = {}) {
+  const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([])
+  const [gameInfo, setGameInfo] = useState<GameInfo | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchLeaderboard = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      const params = new URLSearchParams()
+      if (options.limit) params.set('limit', String(options.limit))
+      if (options.period) params.set('period', options.period)
+
+      const endpoint = options.game
+        ? `/api/leaderboards/${options.game}?${params.toString()}`
+        : `/api/leaderboards?${params.toString()}`
+
+      const res = await fetch(endpoint)
+
+      if (!res.ok) {
+        if (res.status === 404) {
+          throw new Error('Game not found')
+        }
+        throw new Error('Failed to fetch leaderboard')
+      }
+
+      const data: LeaderboardResponse = await res.json()
+      setLeaderboard(data.leaderboard)
+      setGameInfo(data.game || null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [options.limit, options.period, options.game])
+
+  useEffect(() => {
+    fetchLeaderboard()
+  }, [fetchLeaderboard])
+
+  return {
+    leaderboard,
+    gameInfo,
+    isLoading,
+    error,
+    refetch: fetchLeaderboard,
+  }
+}
+
+interface UsePlayerRankingOptions {
+  period?: 'all' | 'weekly' | 'daily'
+  nearby?: number
+}
+
+export function usePlayerRanking(options: UsePlayerRankingOptions = {}) {
+  const [ranking, setRanking] = useState<UserRanking | null>(null)
+  const [nearbyPlayers, setNearbyPlayers] = useState<LeaderboardEntry[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchRanking = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      const params = new URLSearchParams()
+      if (options.period) params.set('period', options.period)
+      if (options.nearby) params.set('nearby', String(options.nearby))
+
+      const res = await fetch(`/api/leaderboards/rankings?${params.toString()}`)
+
+      if (res.status === 401) {
+        // Not authenticated, return empty state
+        setRanking(null)
+        setNearbyPlayers([])
+        return
+      }
+
+      if (!res.ok) {
+        throw new Error('Failed to fetch ranking')
+      }
+
+      const data: RankingsResponse = await res.json()
+      setRanking(data.userRanking)
+      setNearbyPlayers(data.nearbyPlayers)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [options.period, options.nearby])
+
+  useEffect(() => {
+    fetchRanking()
+  }, [fetchRanking])
+
+  return {
+    ranking,
+    nearbyPlayers,
+    isLoading,
+    error,
+    refetch: fetchRanking,
+  }
+}


### PR DESCRIPTION
## Summary
- Add global leaderboards ranked by total GREP earned
- Add game-specific leaderboards for high scores
- Add user ranking API with nearby players
- Support daily, weekly, and all-time periods

## Changes
- `apps/web/src/app/api/leaderboards/route.ts` - Global leaderboard API
- `apps/web/src/app/api/leaderboards/[game]/route.ts` - Game-specific leaderboard
- `apps/web/src/app/api/leaderboards/rankings/route.ts` - User ranking with neighbors
- `apps/web/src/hooks/useLeaderboards.ts` - React hooks for leaderboards

## API Endpoints
- `GET /api/leaderboards?limit=10&period=weekly` - Global rankings
- `GET /api/leaderboards/grep-rails?limit=10` - Game rankings
- `GET /api/leaderboards/rankings?nearby=3` - User's rank (authenticated)

## Test plan
- [ ] Test global leaderboard with various limits
- [ ] Test game-specific leaderboard
- [ ] Test user ranking requires authentication
- [ ] Verify period filters work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)