### PR TITLE
feat(api): add tournament system with registration and scoring

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -33,6 +33,7 @@ model User {
   friendsReceived  Friendship[] @relation("FriendOf")
   eventParticipations EventParticipant[]
   battlePassProgress BattlePassProgress[]
+  tournamentParticipations TournamentParticipant[]
 }
 
 // Game definitions
@@ -412,4 +413,48 @@ enum RewardType {
   BADGE
   MULTIPLIER
   NFT
+}
+
+// Tournament System
+model Tournament {
+  id          String           @id @default(cuid())
+  name        String
+  gameSlug    String
+  entryFee    Int              @default(0)
+  prizePool   Int
+  maxPlayers  Int
+  startTime   DateTime
+  endTime     DateTime
+  status      TournamentStatus @default(REGISTRATION)
+  createdAt   DateTime         @default(now())
+
+  participants TournamentParticipant[]
+
+  @@index([status])
+  @@index([startTime])
+  @@index([gameSlug])
+}
+
+model TournamentParticipant {
+  id           String     @id @default(cuid())
+  tournamentId String
+  userId       String
+  score        Int        @default(0)
+  rank         Int?
+  joinedAt     DateTime   @default(now())
+
+  tournament Tournament @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
+  user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([tournamentId, userId])
+  @@index([tournamentId])
+  @@index([userId])
+  @@index([score])
+}
+
+enum TournamentStatus {
+  REGISTRATION
+  ACTIVE
+  COMPLETED
+  CANCELLED
 }

--- a/apps/web/src/app/api/tournaments/[id]/join/route.ts
+++ b/apps/web/src/app/api/tournaments/[id]/join/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import prisma from '@/lib/db'
+import { parseSessionToken } from '@/lib/auth'
+import { rateLimit } from '@/lib/rate-limit'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const cookieStore = await cookies()
+    const sessionToken = cookieStore.get('session')?.value
+
+    if (!sessionToken) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+    }
+
+    const session = parseSessionToken(sessionToken)
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid session' }, { status: 401 })
+    }
+
+    // Rate limiting
+    const rateCheck = rateLimit(session.address, { interval: 60_000, limit: 20 }, 'tournament-join')
+
+    if (!rateCheck.success) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429 }
+      )
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { walletAddress: session.address },
+    })
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    const tournament = await prisma.tournament.findUnique({
+      where: { id },
+      include: {
+        _count: {
+          select: { participants: true },
+        },
+      },
+    })
+
+    if (!tournament) {
+      return NextResponse.json({ error: 'Tournament not found' }, { status: 404 })
+    }
+
+    // Check tournament status
+    if (tournament.status !== 'REGISTRATION') {
+      return NextResponse.json(
+        { error: 'Tournament is not accepting registrations' },
+        { status: 400 }
+      )
+    }
+
+    // Check if tournament is full
+    if (tournament._count.participants >= tournament.maxPlayers) {
+      return NextResponse.json(
+        { error: 'Tournament is full' },
+        { status: 400 }
+      )
+    }
+
+    const now = new Date()
+    if (now >= tournament.endTime) {
+      return NextResponse.json({ error: 'Tournament has ended' }, { status: 400 })
+    }
+
+    // Check if already participating
+    const existingParticipation = await prisma.tournamentParticipant.findUnique({
+      where: {
+        tournamentId_userId: {
+          tournamentId: id,
+          userId: user.id,
+        },
+      },
+    })
+
+    if (existingParticipation) {
+      return NextResponse.json(
+        { error: 'Already participating in this tournament' },
+        { status: 400 }
+      )
+    }
+
+    // Create participation
+    const participation = await prisma.tournamentParticipant.create({
+      data: {
+        tournamentId: id,
+        userId: user.id,
+        score: 0,
+      },
+    })
+
+    return NextResponse.json({ participation })
+  } catch (error) {
+    console.error('Error joining tournament:', error)
+    return NextResponse.json({ error: 'Failed to join tournament' }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/tournaments/[id]/route.ts
+++ b/apps/web/src/app/api/tournaments/[id]/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import prisma from '@/lib/db'
+import { parseSessionToken } from '@/lib/auth'
+import { rateLimit } from '@/lib/rate-limit'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const ip = request.headers.get('x-forwarded-for') || 'unknown'
+    const rateCheck = rateLimit(ip, { interval: 60_000, limit: 100 }, 'tournament-details')
+
+    if (!rateCheck.success) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429 }
+      )
+    }
+
+    const tournament = await prisma.tournament.findUnique({
+      where: { id },
+      include: {
+        participants: {
+          orderBy: { score: 'desc' },
+          include: {
+            user: {
+              select: {
+                id: true,
+                walletAddress: true,
+                username: true,
+                avatar: true,
+              },
+            },
+          },
+        },
+        _count: {
+          select: { participants: true },
+        },
+      },
+    })
+
+    if (!tournament) {
+      return NextResponse.json({ error: 'Tournament not found' }, { status: 404 })
+    }
+
+    // Check if current user is participating
+    let isParticipating = false
+    let userParticipation = null
+
+    const cookieStore = await cookies()
+    const sessionToken = cookieStore.get('session')?.value
+
+    if (sessionToken) {
+      const session = parseSessionToken(sessionToken)
+      if (session) {
+        const user = await prisma.user.findUnique({
+          where: { walletAddress: session.address },
+        })
+
+        if (user) {
+          const participation = tournament.participants.find((p) => p.userId === user.id)
+          if (participation) {
+            isParticipating = true
+            userParticipation = {
+              id: participation.id,
+              score: participation.score,
+              rank: participation.rank,
+              joinedAt: participation.joinedAt,
+            }
+          }
+        }
+      }
+    }
+
+    return NextResponse.json({
+      tournament: {
+        id: tournament.id,
+        name: tournament.name,
+        gameSlug: tournament.gameSlug,
+        entryFee: tournament.entryFee,
+        prizePool: tournament.prizePool,
+        maxPlayers: tournament.maxPlayers,
+        startTime: tournament.startTime,
+        endTime: tournament.endTime,
+        status: tournament.status,
+        createdAt: tournament.createdAt,
+        participantCount: tournament._count.participants,
+        participants: tournament.participants.map((p) => ({
+          id: p.id,
+          score: p.score,
+          rank: p.rank,
+          joinedAt: p.joinedAt,
+          user: p.user,
+        })),
+        isParticipating,
+        userParticipation,
+      },
+    })
+  } catch (error) {
+    console.error('Error fetching tournament:', error)
+    return NextResponse.json({ error: 'Failed to fetch tournament' }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/tournaments/[id]/submit/route.ts
+++ b/apps/web/src/app/api/tournaments/[id]/submit/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import prisma from '@/lib/db'
+import { parseSessionToken } from '@/lib/auth'
+import { rateLimit } from '@/lib/rate-limit'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const cookieStore = await cookies()
+    const sessionToken = cookieStore.get('session')?.value
+
+    if (!sessionToken) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+    }
+
+    const session = parseSessionToken(sessionToken)
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid session' }, { status: 401 })
+    }
+
+    // Rate limiting
+    const rateCheck = rateLimit(session.address, { interval: 60_000, limit: 30 }, 'tournament-submit')
+
+    if (!rateCheck.success) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429 }
+      )
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { walletAddress: session.address },
+    })
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    const tournament = await prisma.tournament.findUnique({
+      where: { id },
+    })
+
+    if (!tournament) {
+      return NextResponse.json({ error: 'Tournament not found' }, { status: 404 })
+    }
+
+    // Check tournament status
+    if (tournament.status !== 'ACTIVE') {
+      return NextResponse.json(
+        { error: 'Tournament is not active' },
+        { status: 400 }
+      )
+    }
+
+    const now = new Date()
+    if (now < tournament.startTime || now > tournament.endTime) {
+      return NextResponse.json(
+        { error: 'Tournament is not currently running' },
+        { status: 400 }
+      )
+    }
+
+    // Check participation
+    const participation = await prisma.tournamentParticipant.findUnique({
+      where: {
+        tournamentId_userId: {
+          tournamentId: id,
+          userId: user.id,
+        },
+      },
+    })
+
+    if (!participation) {
+      return NextResponse.json(
+        { error: 'Not participating in this tournament' },
+        { status: 400 }
+      )
+    }
+
+    const body = await request.json()
+    const { score } = body
+
+    if (typeof score !== 'number' || score < 0) {
+      return NextResponse.json(
+        { error: 'Invalid score value' },
+        { status: 400 }
+      )
+    }
+
+    // Update score only if new score is higher
+    if (score <= participation.score) {
+      return NextResponse.json(
+        { error: 'Score must be higher than current score' },
+        { status: 400 }
+      )
+    }
+
+    // Update participant score
+    const updatedParticipation = await prisma.tournamentParticipant.update({
+      where: { id: participation.id },
+      data: { score },
+    })
+
+    // Recalculate ranks for all participants in this tournament
+    const allParticipants = await prisma.tournamentParticipant.findMany({
+      where: { tournamentId: id },
+      orderBy: { score: 'desc' },
+    })
+
+    // Update ranks
+    await Promise.all(
+      allParticipants.map((p, index) =>
+        prisma.tournamentParticipant.update({
+          where: { id: p.id },
+          data: { rank: index + 1 },
+        })
+      )
+    )
+
+    // Get updated participation with rank
+    const finalParticipation = await prisma.tournamentParticipant.findUnique({
+      where: { id: participation.id },
+    })
+
+    return NextResponse.json({ participation: finalParticipation })
+  } catch (error) {
+    console.error('Error submitting tournament score:', error)
+    return NextResponse.json({ error: 'Failed to submit score' }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/tournaments/route.ts
+++ b/apps/web/src/app/api/tournaments/route.ts
@@ -1,0 +1,166 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import prisma from '@/lib/db'
+import { parseSessionToken } from '@/lib/auth'
+import { rateLimit } from '@/lib/rate-limit'
+
+export async function GET(request: NextRequest) {
+  try {
+    // Rate limiting
+    const ip = request.headers.get('x-forwarded-for') || 'unknown'
+    const rateCheck = rateLimit(ip, { interval: 60_000, limit: 100 }, 'tournaments-list')
+
+    if (!rateCheck.success) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429 }
+      )
+    }
+
+    const { searchParams } = new URL(request.url)
+    const status = searchParams.get('status')
+    const gameSlug = searchParams.get('gameSlug')
+    const limit = parseInt(searchParams.get('limit') || '20')
+
+    const where: Record<string, unknown> = {}
+
+    if (status) {
+      where.status = status
+    }
+
+    if (gameSlug) {
+      where.gameSlug = gameSlug
+    }
+
+    const tournaments = await prisma.tournament.findMany({
+      where,
+      include: {
+        participants: {
+          take: 10,
+          orderBy: { score: 'desc' },
+          include: {
+            user: {
+              select: {
+                id: true,
+                walletAddress: true,
+                username: true,
+                avatar: true,
+              },
+            },
+          },
+        },
+        _count: {
+          select: { participants: true },
+        },
+      },
+      orderBy: [
+        { status: 'asc' },
+        { startTime: 'asc' },
+      ],
+      take: limit,
+    })
+
+    const formattedTournaments = tournaments.map((tournament) => ({
+      id: tournament.id,
+      name: tournament.name,
+      gameSlug: tournament.gameSlug,
+      entryFee: tournament.entryFee,
+      prizePool: tournament.prizePool,
+      maxPlayers: tournament.maxPlayers,
+      startTime: tournament.startTime,
+      endTime: tournament.endTime,
+      status: tournament.status,
+      createdAt: tournament.createdAt,
+      participantCount: tournament._count.participants,
+      topParticipants: tournament.participants.map((p) => ({
+        id: p.id,
+        score: p.score,
+        rank: p.rank,
+        joinedAt: p.joinedAt,
+        user: p.user,
+      })),
+    }))
+
+    return NextResponse.json({ tournaments: formattedTournaments })
+  } catch (error) {
+    console.error('Error fetching tournaments:', error)
+    return NextResponse.json({ error: 'Failed to fetch tournaments' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const cookieStore = await cookies()
+    const sessionToken = cookieStore.get('session')?.value
+
+    if (!sessionToken) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+    }
+
+    const session = parseSessionToken(sessionToken)
+    if (!session) {
+      return NextResponse.json({ error: 'Invalid session' }, { status: 401 })
+    }
+
+    // Rate limiting
+    const rateCheck = rateLimit(session.address, { interval: 60_000, limit: 5 }, 'tournament-create')
+
+    if (!rateCheck.success) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429 }
+      )
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { walletAddress: session.address },
+    })
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    const body = await request.json()
+    const { name, gameSlug, entryFee, prizePool, maxPlayers, startTime, endTime } = body
+
+    // Validation
+    if (!name || !gameSlug || !maxPlayers || !startTime || !endTime) {
+      return NextResponse.json(
+        { error: 'Missing required fields' },
+        { status: 400 }
+      )
+    }
+
+    if (new Date(startTime) >= new Date(endTime)) {
+      return NextResponse.json(
+        { error: 'Start time must be before end time' },
+        { status: 400 }
+      )
+    }
+
+    if (maxPlayers < 2) {
+      return NextResponse.json(
+        { error: 'Tournament must allow at least 2 players' },
+        { status: 400 }
+      )
+    }
+
+    const tournament = await prisma.tournament.create({
+      data: {
+        name,
+        gameSlug,
+        entryFee: entryFee || 0,
+        prizePool: prizePool || 0,
+        maxPlayers,
+        startTime: new Date(startTime),
+        endTime: new Date(endTime),
+        status: 'REGISTRATION',
+      },
+    })
+
+    return NextResponse.json({ tournament }, { status: 201 })
+  } catch (error) {
+    console.error('Error creating tournament:', error)
+    return NextResponse.json({ error: 'Failed to create tournament' }, { status: 500 })
+  }
+}

--- a/apps/web/src/hooks/useTournaments.ts
+++ b/apps/web/src/hooks/useTournaments.ts
@@ -1,0 +1,194 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+interface TournamentUser {
+  id: string
+  walletAddress: string
+  username: string | null
+  avatar: string | null
+}
+
+interface TournamentParticipant {
+  id: string
+  score: number
+  rank: number | null
+  joinedAt: string
+  user: TournamentUser
+}
+
+interface Tournament {
+  id: string
+  name: string
+  gameSlug: string
+  entryFee: number
+  prizePool: number
+  maxPlayers: number
+  startTime: string
+  endTime: string
+  status: 'REGISTRATION' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED'
+  createdAt: string
+  participantCount: number
+  topParticipants?: TournamentParticipant[]
+  participants?: TournamentParticipant[]
+  isParticipating?: boolean
+  userParticipation?: {
+    id: string
+    score: number
+    rank: number | null
+    joinedAt: string
+  } | null
+}
+
+interface UseTournamentsOptions {
+  status?: string
+  gameSlug?: string
+  limit?: number
+}
+
+export function useTournaments(options: UseTournamentsOptions = {}) {
+  const [tournaments, setTournaments] = useState<Tournament[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchTournaments = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      const params = new URLSearchParams()
+      if (options.status) params.set('status', options.status)
+      if (options.gameSlug) params.set('gameSlug', options.gameSlug)
+      if (options.limit) params.set('limit', String(options.limit))
+
+      const res = await fetch(`/api/tournaments?${params.toString()}`)
+
+      if (!res.ok) {
+        throw new Error('Failed to fetch tournaments')
+      }
+
+      const data = await res.json()
+      setTournaments(data.tournaments || [])
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [options.status, options.gameSlug, options.limit])
+
+  useEffect(() => {
+    fetchTournaments()
+  }, [fetchTournaments])
+
+  return {
+    tournaments,
+    isLoading,
+    error,
+    refetch: fetchTournaments,
+  }
+}
+
+export function useTournament(tournamentId: string) {
+  const [tournament, setTournament] = useState<Tournament | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchTournament = useCallback(async () => {
+    if (!tournamentId) return
+
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      const res = await fetch(`/api/tournaments/${tournamentId}`)
+
+      if (!res.ok) {
+        if (res.status === 404) {
+          throw new Error('Tournament not found')
+        }
+        throw new Error('Failed to fetch tournament')
+      }
+
+      const data = await res.json()
+      setTournament(data.tournament)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [tournamentId])
+
+  useEffect(() => {
+    fetchTournament()
+  }, [fetchTournament])
+
+  const joinTournament = async () => {
+    if (!tournamentId) return
+
+    const res = await fetch(`/api/tournaments/${tournamentId}/join`, {
+      method: 'POST',
+    })
+
+    if (!res.ok) {
+      const data = await res.json()
+      throw new Error(data.error || 'Failed to join tournament')
+    }
+
+    await fetchTournament()
+    return res.json()
+  }
+
+  const submitScore = async (score: number) => {
+    if (!tournamentId) return
+
+    const res = await fetch(`/api/tournaments/${tournamentId}/submit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ score }),
+    })
+
+    if (!res.ok) {
+      const data = await res.json()
+      throw new Error(data.error || 'Failed to submit score')
+    }
+
+    await fetchTournament()
+    return res.json()
+  }
+
+  const getTimeRemaining = (): { days: number; hours: number; minutes: number } | null => {
+    if (!tournament) return null
+
+    const now = new Date()
+    let targetDate: Date
+
+    if (tournament.status === 'REGISTRATION') {
+      targetDate = new Date(tournament.startTime)
+    } else if (tournament.status === 'ACTIVE') {
+      targetDate = new Date(tournament.endTime)
+    } else {
+      return null
+    }
+
+    const diff = targetDate.getTime() - now.getTime()
+    if (diff <= 0) return null
+
+    return {
+      days: Math.floor(diff / (1000 * 60 * 60 * 24)),
+      hours: Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)),
+      minutes: Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60)),
+    }
+  }
+
+  return {
+    tournament,
+    isLoading,
+    error,
+    joinTournament,
+    submitScore,
+    getTimeRemaining,
+    refetch: fetchTournament,
+  }
+}


### PR DESCRIPTION
## Summary
- Add Tournament and TournamentParticipant models
- Add tournament CRUD and participation APIs
- Add score submission with automatic ranking
- Add React hooks for tournament management

## Schema Changes
- Add `Tournament` model with status, entry fee, prize pool
- Add `TournamentParticipant` with score and ranking
- Add `TournamentStatus` enum (REGISTRATION, ACTIVE, COMPLETED, CANCELLED)
- Add relation to User model

## API Endpoints
- `GET /api/tournaments` - List tournaments with filters
- `POST /api/tournaments` - Create tournament
- `GET /api/tournaments/[id]` - Tournament details
- `POST /api/tournaments/[id]/join` - Join tournament
- `POST /api/tournaments/[id]/submit` - Submit score

## Test plan
- [ ] Run Prisma migration: `npx prisma migrate dev --name add_tournaments`
- [ ] Test tournament creation and listing
- [ ] Test join validation (status, capacity, duplicate)
- [ ] Test score submission and ranking updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)