### PR TITLE
feat(subgraph): add The Graph subgraph for blockchain indexing

### DIFF
--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@grepcoin/subgraph",
+  "version": "0.1.0",
+  "scripts": {
+    "codegen": "graph codegen",
+    "build": "graph build",
+    "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ grepcoin/grepcoin-base",
+    "create-local": "graph create --node http://localhost:8020/ grepcoin/grepcoin",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 grepcoin/grepcoin"
+  },
+  "dependencies": {
+    "@graphprotocol/graph-cli": "^0.68.0",
+    "@graphprotocol/graph-ts": "^0.32.0"
+  }
+}

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -1,0 +1,43 @@
+type TokenHolder @entity {
+  id: ID!
+  address: Bytes!
+  balance: BigInt!
+  transferCount: Int!
+  firstTransferAt: BigInt!
+  lastTransferAt: BigInt!
+}
+
+type Transfer @entity {
+  id: ID!
+  from: Bytes!
+  to: Bytes!
+  amount: BigInt!
+  timestamp: BigInt!
+  blockNumber: BigInt!
+  transactionHash: Bytes!
+}
+
+type StakePosition @entity {
+  id: ID!
+  user: Bytes!
+  amount: BigInt!
+  tier: Int!
+  stakedAt: BigInt!
+  lastClaimAt: BigInt!
+}
+
+type AchievementMint @entity {
+  id: ID!
+  user: Bytes!
+  achievementId: BigInt!
+  timestamp: BigInt!
+  transactionHash: Bytes!
+}
+
+type GlobalStats @entity {
+  id: ID!
+  totalHolders: Int!
+  totalTransfers: Int!
+  totalStaked: BigInt!
+  totalAchievementsMinted: Int!
+}

--- a/packages/subgraph/src/achievements.ts
+++ b/packages/subgraph/src/achievements.ts
@@ -1,0 +1,38 @@
+import { Transfer as TransferEvent } from '../generated/GrepAchievements/GrepAchievements';
+import { AchievementMint, GlobalStats } from '../generated/schema';
+import { BigInt } from '@graphprotocol/graph-ts';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const GLOBAL_STATS_ID = 'global';
+
+export function handleAchievementMint(event: TransferEvent): void {
+  // Only track mints (from zero address)
+  if (event.params.from.toHex() == ZERO_ADDRESS) {
+    let mintId = event.transaction.hash.toHex() + '-' + event.logIndex.toString();
+    let mint = new AchievementMint(mintId);
+
+    mint.user = event.params.to;
+    mint.achievementId = event.params.tokenId;
+    mint.timestamp = event.block.timestamp;
+    mint.transactionHash = event.transaction.hash;
+    mint.save();
+
+    // Update global achievement count
+    let stats = getOrCreateGlobalStats();
+    stats.totalAchievementsMinted = stats.totalAchievementsMinted + 1;
+    stats.save();
+  }
+}
+
+function getOrCreateGlobalStats(): GlobalStats {
+  let stats = GlobalStats.load(GLOBAL_STATS_ID);
+  if (stats == null) {
+    stats = new GlobalStats(GLOBAL_STATS_ID);
+    stats.totalHolders = 0;
+    stats.totalTransfers = 0;
+    stats.totalStaked = BigInt.fromI32(0);
+    stats.totalAchievementsMinted = 0;
+    stats.save();
+  }
+  return stats as GlobalStats;
+}

--- a/packages/subgraph/src/grep-token.ts
+++ b/packages/subgraph/src/grep-token.ts
@@ -1,0 +1,70 @@
+import { Transfer as TransferEvent } from '../generated/GrepToken/GrepToken';
+import { Transfer, TokenHolder, GlobalStats } from '../generated/schema';
+import { BigInt, Bytes } from '@graphprotocol/graph-ts';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const GLOBAL_STATS_ID = 'global';
+
+export function handleTransfer(event: TransferEvent): void {
+  // Create Transfer entity
+  let transfer = new Transfer(
+    event.transaction.hash.toHex() + '-' + event.logIndex.toString()
+  );
+  transfer.from = event.params.from;
+  transfer.to = event.params.to;
+  transfer.amount = event.params.value;
+  transfer.timestamp = event.block.timestamp;
+  transfer.blockNumber = event.block.number;
+  transfer.transactionHash = event.transaction.hash;
+  transfer.save();
+
+  // Update sender's balance (if not mint)
+  if (event.params.from.toHex() != ZERO_ADDRESS) {
+    let fromHolder = TokenHolder.load(event.params.from.toHex());
+    if (fromHolder != null) {
+      fromHolder.balance = fromHolder.balance.minus(event.params.value);
+      fromHolder.transferCount = fromHolder.transferCount + 1;
+      fromHolder.lastTransferAt = event.block.timestamp;
+      fromHolder.save();
+    }
+  }
+
+  // Update recipient's balance (if not burn)
+  if (event.params.to.toHex() != ZERO_ADDRESS) {
+    let toHolder = TokenHolder.load(event.params.to.toHex());
+    if (toHolder == null) {
+      toHolder = new TokenHolder(event.params.to.toHex());
+      toHolder.address = event.params.to;
+      toHolder.balance = BigInt.fromI32(0);
+      toHolder.transferCount = 0;
+      toHolder.firstTransferAt = event.block.timestamp;
+
+      // Update global holder count
+      let stats = getOrCreateGlobalStats();
+      stats.totalHolders = stats.totalHolders + 1;
+      stats.save();
+    }
+    toHolder.balance = toHolder.balance.plus(event.params.value);
+    toHolder.transferCount = toHolder.transferCount + 1;
+    toHolder.lastTransferAt = event.block.timestamp;
+    toHolder.save();
+  }
+
+  // Update global transfer count
+  let stats = getOrCreateGlobalStats();
+  stats.totalTransfers = stats.totalTransfers + 1;
+  stats.save();
+}
+
+function getOrCreateGlobalStats(): GlobalStats {
+  let stats = GlobalStats.load(GLOBAL_STATS_ID);
+  if (stats == null) {
+    stats = new GlobalStats(GLOBAL_STATS_ID);
+    stats.totalHolders = 0;
+    stats.totalTransfers = 0;
+    stats.totalStaked = BigInt.fromI32(0);
+    stats.totalAchievementsMinted = 0;
+    stats.save();
+  }
+  return stats as GlobalStats;
+}

--- a/packages/subgraph/src/staking-pool.ts
+++ b/packages/subgraph/src/staking-pool.ts
@@ -1,0 +1,78 @@
+import {
+  Staked as StakedEvent,
+  Unstaked as UnstakedEvent,
+  RewardsClaimed as RewardsClaimedEvent
+} from '../generated/GrepStakingPool/GrepStakingPool';
+import { StakePosition, GlobalStats } from '../generated/schema';
+import { BigInt } from '@graphprotocol/graph-ts';
+
+const GLOBAL_STATS_ID = 'global';
+
+export function handleStaked(event: StakedEvent): void {
+  let stakeId = event.params.user.toHex();
+  let stake = StakePosition.load(stakeId);
+
+  if (stake == null) {
+    stake = new StakePosition(stakeId);
+    stake.user = event.params.user;
+    stake.amount = BigInt.fromI32(0);
+    stake.tier = 0;
+    stake.stakedAt = event.block.timestamp;
+    stake.lastClaimAt = event.block.timestamp;
+  }
+
+  stake.amount = stake.amount.plus(event.params.amount);
+  stake.tier = event.params.tier;
+  stake.stakedAt = event.block.timestamp;
+  stake.save();
+
+  // Update global staked amount
+  let stats = getOrCreateGlobalStats();
+  stats.totalStaked = stats.totalStaked.plus(event.params.amount);
+  stats.save();
+}
+
+export function handleUnstaked(event: UnstakedEvent): void {
+  let stakeId = event.params.user.toHex();
+  let stake = StakePosition.load(stakeId);
+
+  if (stake != null) {
+    stake.amount = stake.amount.minus(event.params.amount);
+
+    // If fully unstaked, set amount to zero
+    if (stake.amount.le(BigInt.fromI32(0))) {
+      stake.amount = BigInt.fromI32(0);
+      stake.tier = 0;
+    }
+
+    stake.save();
+
+    // Update global staked amount
+    let stats = getOrCreateGlobalStats();
+    stats.totalStaked = stats.totalStaked.minus(event.params.amount);
+    stats.save();
+  }
+}
+
+export function handleRewardsClaimed(event: RewardsClaimedEvent): void {
+  let stakeId = event.params.user.toHex();
+  let stake = StakePosition.load(stakeId);
+
+  if (stake != null) {
+    stake.lastClaimAt = event.block.timestamp;
+    stake.save();
+  }
+}
+
+function getOrCreateGlobalStats(): GlobalStats {
+  let stats = GlobalStats.load(GLOBAL_STATS_ID);
+  if (stats == null) {
+    stats = new GlobalStats(GLOBAL_STATS_ID);
+    stats.totalHolders = 0;
+    stats.totalTransfers = 0;
+    stats.totalStaked = BigInt.fromI32(0);
+    stats.totalAchievementsMinted = 0;
+    stats.save();
+  }
+  return stats as GlobalStats;
+}

--- a/packages/subgraph/subgraph.yaml
+++ b/packages/subgraph/subgraph.yaml
@@ -1,0 +1,72 @@
+specVersion: 0.0.5
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum
+    name: GrepToken
+    network: base-sepolia
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: GrepToken
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Transfer
+        - TokenHolder
+        - GlobalStats
+      abis:
+        - name: GrepToken
+          file: ../contracts/artifacts/contracts/GrepToken.sol/GrepToken.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
+      file: ./src/grep-token.ts
+  - kind: ethereum
+    name: GrepStakingPool
+    network: base-sepolia
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: GrepStakingPool
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - StakePosition
+        - GlobalStats
+      abis:
+        - name: GrepStakingPool
+          file: ../contracts/artifacts/contracts/GrepStakingPool.sol/GrepStakingPool.json
+      eventHandlers:
+        - event: Staked(indexed address,uint256,uint8)
+          handler: handleStaked
+        - event: Unstaked(indexed address,uint256)
+          handler: handleUnstaked
+        - event: RewardsClaimed(indexed address,uint256)
+          handler: handleRewardsClaimed
+      file: ./src/staking-pool.ts
+  - kind: ethereum
+    name: GrepAchievements
+    network: base-sepolia
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: GrepAchievements
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - AchievementMint
+        - GlobalStats
+      abis:
+        - name: GrepAchievements
+          file: ../contracts/artifacts/contracts/GrepAchievements.sol/GrepAchievements.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,indexed uint256)
+          handler: handleAchievementMint
+      file: ./src/achievements.ts


### PR DESCRIPTION
## Summary
- Complete subgraph package for indexing GrepCoin contracts
- Handlers for Token, Staking, and Achievements events
- GraphQL schema for querying blockchain data
- Deployment scripts for The Graph Studio

## Files Added
- `packages/subgraph/package.json` - Package configuration
- `packages/subgraph/subgraph.yaml` - Subgraph manifest
- `packages/subgraph/schema.graphql` - GraphQL schema
- `packages/subgraph/src/grep-token.ts` - Token handlers
- `packages/subgraph/src/staking-pool.ts` - Staking handlers
- `packages/subgraph/src/achievements.ts` - NFT handlers

## Test Plan
- [ ] Update contract addresses after deployment
- [ ] Run codegen to generate types
- [ ] Deploy to The Graph Studio
- [ ] Test queries against indexed data

🤖 Generated with [Claude Code](https://claude.com/claude-code)