### PR TITLE
feat(theme): add dark/light/system theme toggle

### DIFF
--- a/apps/web/src/components/ThemeProvider.tsx
+++ b/apps/web/src/components/ThemeProvider.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useState, useEffect, ReactNode } from 'react'
+import { ThemeContext } from '@/hooks/useTheme'
+import type { Theme } from '@/lib/theme'
+
+interface Props {
+  children: ReactNode
+}
+
+export function ThemeProvider({ children }: Props) {
+  const [theme, setThemeState] = useState<Theme>('dark')
+  const [resolvedTheme, setResolvedTheme] = useState<'dark' | 'light'>('dark')
+
+  useEffect(() => {
+    const saved = localStorage.getItem('theme') as Theme | null
+    if (saved) {
+      setThemeState(saved)
+    }
+  }, [])
+
+  useEffect(() => {
+    const root = document.documentElement
+
+    const applyTheme = (t: 'dark' | 'light') => {
+      root.classList.remove('dark', 'light')
+      root.classList.add(t)
+      setResolvedTheme(t)
+    }
+
+    if (theme === 'system') {
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+      applyTheme(mediaQuery.matches ? 'dark' : 'light')
+
+      const handler = (e: MediaQueryListEvent) => {
+        applyTheme(e.matches ? 'dark' : 'light')
+      }
+      mediaQuery.addEventListener('change', handler)
+      return () => mediaQuery.removeEventListener('change', handler)
+    } else {
+      applyTheme(theme)
+    }
+  }, [theme])
+
+  const setTheme = (newTheme: Theme) => {
+    setThemeState(newTheme)
+    localStorage.setItem('theme', newTheme)
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}

--- a/apps/web/src/components/ThemeSelect.tsx
+++ b/apps/web/src/components/ThemeSelect.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useState } from 'react'
+import { useTheme } from '@/hooks/useTheme'
+import { themes, Theme } from '@/lib/theme'
+
+const themeIcons: Record<Theme, string> = {
+  dark: '🌙',
+  light: '☀️',
+  system: '💻',
+}
+
+const themeLabels: Record<Theme, string> = {
+  dark: 'Dark Mode',
+  light: 'Light Mode',
+  system: 'System Default',
+}
+
+export function ThemeSelect() {
+  const { theme, setTheme } = useTheme()
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center justify-between w-full px-4 py-3 rounded-lg bg-gray-800 hover:bg-gray-700"
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-xl">{themeIcons[theme]}</span>
+          <span>{themeLabels[theme]}</span>
+        </div>
+        <span className="text-gray-400">▼</span>
+      </button>
+
+      {isOpen && (
+        <div className="absolute left-0 right-0 mt-2 py-2 bg-gray-800 rounded-lg shadow-xl z-50">
+          {themes.map((t) => (
+            <button
+              key={t}
+              onClick={() => {
+                setTheme(t)
+                setIsOpen(false)
+              }}
+              className={`w-full px-4 py-3 flex items-center gap-3 hover:bg-gray-700 ${
+                theme === t ? 'text-emerald-400' : 'text-white'
+              }`}
+            >
+              <span className="text-xl">{themeIcons[t]}</span>
+              <span>{themeLabels[t]}</span>
+              {theme === t && <span className="ml-auto">✓</span>}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useTheme } from '@/hooks/useTheme'
+import { themes, Theme } from '@/lib/theme'
+
+const themeIcons: Record<Theme, string> = {
+  dark: '🌙',
+  light: '☀️',
+  system: '💻',
+}
+
+const themeLabels: Record<Theme, string> = {
+  dark: 'Dark',
+  light: 'Light',
+  system: 'System',
+}
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+
+  const cycleTheme = () => {
+    const currentIndex = themes.indexOf(theme)
+    const nextIndex = (currentIndex + 1) % themes.length
+    setTheme(themes[nextIndex])
+  }
+
+  return (
+    <button
+      onClick={cycleTheme}
+      className="flex items-center gap-2 px-3 py-2 rounded-lg bg-gray-800 dark:bg-gray-800 light:bg-gray-200 hover:bg-gray-700 dark:hover:bg-gray-700 light:hover:bg-gray-300 text-sm transition-colors"
+      title={`Theme: ${themeLabels[theme]}`}
+    >
+      <span>{themeIcons[theme]}</span>
+      <span className="hidden sm:inline">{themeLabels[theme]}</span>
+    </button>
+  )
+}

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -1,0 +1,20 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+import type { Theme } from '@/lib/theme'
+
+interface ThemeContextType {
+  theme: Theme
+  resolvedTheme: 'dark' | 'light'
+  setTheme: (theme: Theme) => void
+}
+
+export const ThemeContext = createContext<ThemeContextType>({
+  theme: 'dark',
+  resolvedTheme: 'dark',
+  setTheme: () => {},
+})
+
+export function useTheme() {
+  return useContext(ThemeContext)
+}

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,0 +1,32 @@
+export type Theme = 'dark' | 'light' | 'system'
+
+export const themes: Theme[] = ['dark', 'light', 'system']
+
+export const themeColors = {
+  dark: {
+    background: '#0a0a0a',
+    foreground: '#fafafa',
+    card: '#1a1a1a',
+    cardForeground: '#fafafa',
+    primary: '#10b981',
+    primaryForeground: '#ffffff',
+    secondary: '#27272a',
+    secondaryForeground: '#fafafa',
+    muted: '#27272a',
+    mutedForeground: '#a1a1aa',
+    border: '#27272a',
+  },
+  light: {
+    background: '#ffffff',
+    foreground: '#0a0a0a',
+    card: '#f4f4f5',
+    cardForeground: '#0a0a0a',
+    primary: '#059669',
+    primaryForeground: '#ffffff',
+    secondary: '#e4e4e7',
+    secondaryForeground: '#0a0a0a',
+    muted: '#f4f4f5',
+    mutedForeground: '#71717a',
+    border: '#e4e4e7',
+  },
+}


### PR DESCRIPTION
## Summary
- Create theme configuration with dark/light/system modes
- Build ThemeProvider with localStorage persistence
- Add ThemeToggle button and ThemeSelect dropdown
- Support system preference detection

## Test plan
- [ ] Toggle between themes
- [ ] Verify system preference works
- [ ] Check persistence across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)