### PR TITLE
chore: cleanup ESLint warnings (203 → 190)

### DIFF
--- a/apps/web/src/app/api/admin/distribute-rewards/route.ts
+++ b/apps/web/src/app/api/admin/distribute-rewards/route.ts
@@ -208,7 +208,7 @@ export async function POST(request: NextRequest) {
 }
 
 // GET - Get distribution status and history (admin only)
-export async function GET(request: NextRequest) {
+export async function GET(_request: NextRequest) {
   try {
     const cookieStore = await cookies()
     const sessionToken = cookieStore.get('session')?.value

--- a/apps/web/src/app/api/admin/stats/route.ts
+++ b/apps/web/src/app/api/admin/stats/route.ts
@@ -5,7 +5,7 @@ import { parseSessionToken } from '@/lib/auth'
 
 const ADMIN_WALLETS = [process.env.ADMIN_WALLET?.toLowerCase()]
 
-export async function GET(request: NextRequest) {
+export async function GET(_request: NextRequest) {
   const cookieStore = await cookies()
   const sessionToken = cookieStore.get('session')?.value
 

--- a/apps/web/src/app/api/friends/route.ts
+++ b/apps/web/src/app/api/friends/route.ts
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 import prisma from '@/lib/db'
 import { parseSessionToken } from '@/lib/auth'
 
-export async function GET(request: NextRequest) {
+export async function GET(_request: NextRequest) {
   try {
     const cookieStore = await cookies()
     const sessionToken = cookieStore.get('session')?.value

--- a/apps/web/src/app/api/leaderboards/rewards/claim/route.ts
+++ b/apps/web/src/app/api/leaderboards/rewards/claim/route.ts
@@ -192,7 +192,7 @@ export async function POST(request: NextRequest) {
 }
 
 // GET - Get user's claimable rewards
-export async function GET(request: NextRequest) {
+export async function GET(_request: NextRequest) {
   try {
     const cookieStore = await cookies()
     const sessionToken = cookieStore.get('session')?.value

--- a/apps/web/src/app/games/bug-hunter/page.tsx
+++ b/apps/web/src/app/games/bug-hunter/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, Play, RotateCcw, Volume2, VolumeX, Trophy, Bug, Zap, Heart, Target } from 'lucide-react'
+import { ArrowLeft, Play, RotateCcw, Volume2, VolumeX, Trophy, Bug, Heart, Target, Zap } from 'lucide-react'
 import { useGameScore } from '@/hooks/useGameScore'
 import { useAuth } from '@/context/AuthContext'
 import {

--- a/apps/web/src/app/games/crypto-snake/page.tsx
+++ b/apps/web/src/app/games/crypto-snake/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, Play, Pause, RotateCcw, Volume2, VolumeX, Trophy, Coins, Zap, ArrowUp, ArrowDown, ArrowLeftIcon, ArrowRight } from 'lucide-react'
+import { ArrowLeft, Play, Pause, RotateCcw, Volume2, VolumeX, Trophy, Coins, ArrowUp, ArrowDown, ArrowLeftIcon, ArrowRight } from 'lucide-react'
 import { useGameScore } from '@/hooks/useGameScore'
 import { useAuth } from '@/context/AuthContext'
 import {

--- a/apps/web/src/app/games/grep-rails/page.tsx
+++ b/apps/web/src/app/games/grep-rails/page.tsx
@@ -22,7 +22,6 @@ import {
   drawNeonText,
   drawGlowingRect,
   hexToRgba,
-  easing,
 } from '@/lib/gameUtils'
 
 // Enhanced pattern challenges with difficulty tiers

--- a/apps/web/src/app/games/memory-match/page.tsx
+++ b/apps/web/src/app/games/memory-match/page.tsx
@@ -56,7 +56,6 @@ interface GameState {
   level: number
 }
 
-const GRID_COLS = 4
 const INITIAL_TIME = 90
 
 export default function MemoryMatchGame() {

--- a/apps/web/src/app/games/pipe-dream/page.tsx
+++ b/apps/web/src/app/games/pipe-dream/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, Play, Pause, RotateCcw, Volume2, VolumeX, Trophy, Zap, Clock } from 'lucide-react'
+import { ArrowLeft, Play, Pause, RotateCcw, Volume2, VolumeX, Trophy, Clock } from 'lucide-react'
 import { useGameScore } from '@/hooks/useGameScore'
 import { useAuth } from '@/context/AuthContext'
 import {

--- a/apps/web/src/app/games/quantum-grep/page.tsx
+++ b/apps/web/src/app/games/quantum-grep/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, Play, Pause, RotateCcw, Eye, Zap, Target, Sparkles } from 'lucide-react'
+import { ArrowLeft, Play, RotateCcw, Eye, Zap, Target, Sparkles } from 'lucide-react'
 import { playSound, createExplosion, createTextParticle, updateParticle, drawParticle, Particle, GREP_COLORS } from '@/lib/gameUtils'
 import { useStaking } from '@/context/StakingContext'
 import { MultiplierIndicator } from '@/components/StakingBadge'

--- a/apps/web/src/app/games/regex-crossword/page.tsx
+++ b/apps/web/src/app/games/regex-crossword/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { ArrowLeft, Play, RotateCcw, Volume2, VolumeX, Trophy, Lightbulb, Check, X, Clock, Grid3X3 } from 'lucide-react'
 import { useGameScore } from '@/hooks/useGameScore'
 import { useAuth } from '@/context/AuthContext'
-import { playSound, GREP_COLORS } from '@/lib/gameUtils'
+import { playSound } from '@/lib/gameUtils'
 
 interface Puzzle {
   size: number

--- a/apps/web/src/app/games/stack-panic/page.tsx
+++ b/apps/web/src/app/games/stack-panic/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, Play, RotateCcw, Volume2, VolumeX, Trophy, AlertTriangle, Keyboard, Zap } from 'lucide-react'
+import { ArrowLeft, Play, RotateCcw, Volume2, VolumeX, Trophy, AlertTriangle, Keyboard } from 'lucide-react'
 import { useGameScore } from '@/hooks/useGameScore'
 import { useAuth } from '@/context/AuthContext'
 import {

--- a/apps/web/src/app/games/syntax-sprint/page.tsx
+++ b/apps/web/src/app/games/syntax-sprint/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react'
 import Link from 'next/link'
-import { ArrowLeft, Play, Pause, RotateCcw, Volume2, VolumeX, Trophy, Code, Zap, ArrowDown, ArrowLeftIcon, ArrowRight, RotateCw } from 'lucide-react'
+import { ArrowLeft, Play, Pause, RotateCcw, Volume2, VolumeX, Trophy, ArrowDown, ArrowLeftIcon, ArrowRight, RotateCw } from 'lucide-react'
 import { useGameScore } from '@/hooks/useGameScore'
 import { useAuth } from '@/context/AuthContext'
 import {


### PR DESCRIPTION
## Summary
- Reduced ESLint warnings from 203 to 190 (-13 warnings)
- Focused on unused imports and variables in game files and API routes

## Changes

### Game Files
- Removed unused icon imports (Zap, Code, Pause) from:
  - crypto-snake, pipe-dream, quantum-grep, stack-panic, syntax-sprint
- Removed unused constants:
  - `GRID_COLS` from memory-match
  - `easing` from grep-rails  
  - `GREP_COLORS` from regex-crossword

### API Routes  
- Fixed unused `request` parameter warnings in routes that don't use the request body
- Restored `request` parameter where it was actually being used (for `request.json()`)

## Remaining Work
- 190 warnings remain (mostly `any` types and some unused variables)
- These require more careful refactoring

## Test plan
- [x] Build passes
- [x] Lint runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)